### PR TITLE
'current_page' not always present in response pagination metadata

### DIFF
--- a/UKFast.API.Client.Core.Tests/Structures.cs
+++ b/UKFast.API.Client.Core.Tests/Structures.cs
@@ -56,17 +56,28 @@ namespace UKFast.API.Client.Core.Tests
     {
         public System.Net.HttpStatusCode StatusCode { get; set; }
         public string Content { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
         public RequestHandler RequestHandler { get; set; }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             this.RequestHandler?.Invoke(request);
 
-            return Task.FromResult(new HttpResponseMessage()
+            HttpResponseMessage responseMessage = new HttpResponseMessage()
             {
                 StatusCode = this.StatusCode,
                 Content = new StringContent(this.Content ?? "", Encoding.UTF8, "application/json")
-            });
+            };
+
+            if (this.Headers != null)
+            {
+                foreach (KeyValuePair<string, string> header in this.Headers)
+                {
+                    responseMessage.Headers.Add(header.Key, header.Value);
+                }
+            }
+
+            return Task.FromResult(responseMessage);
         }
     }
 

--- a/UKFast.API.Client.Core.Tests/UKFastClientTests.cs
+++ b/UKFast.API.Client.Core.Tests/UKFastClientTests.cs
@@ -55,37 +55,41 @@ namespace UKFast.API.Client.Core.Tests
         [TestMethod]
         public async Task GetAllAsync_ExpectedCalls()
         {
-            ClientRequestParameters parameters = new ClientRequestParameters()
-            {
-                Pagination = new ClientRequestPagination()
-            };
-
             ClientResponse<IList<ModelBase>> mockPage1Response = GetListResponse(new List<ModelBase>()
             {
                 new ModelBase(),
                 new ModelBase(),
             }, 3);
-            mockPage1Response.Body.Metadata.Pagination.CurrentPage = 1;
 
             ClientResponse<IList<ModelBase>> mockPage2Response = GetListResponse(new List<ModelBase>()
             {
                 new ModelBase(),
                 new ModelBase(),
             }, 3);
-            mockPage2Response.Body.Metadata.Pagination.CurrentPage = 2;
 
             ClientResponse<IList<ModelBase>> mockPage3Response = GetListResponse(new List<ModelBase>()
             {
                 new ModelBase(),
             }, 3);
-            mockPage3Response.Body.Metadata.Pagination.CurrentPage = 3;
 
             IUKFastClient mockClient = Substitute.For<IUKFastClient>();
-            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 2)).Returns(Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", parameters, mockPage2Response)));
-            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 3)).Returns(Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", parameters, mockPage3Response)));
+            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 2)).Returns(x =>
+            {
+                return Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", x.ArgAt<ClientRequestParameters>(1), mockPage2Response));
+            });
+            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 3)).Returns(x =>
+            {
+                return Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", x.ArgAt<ClientRequestParameters>(1), mockPage3Response));
+            });
 
             IUKFastClient client = new TestUKFastClient(null);
-            IList<ModelBase> items = await client.GetAllAsync(async (ClientRequestParameters p) => new Paginated<ModelBase>(mockClient, "testresource", p, mockPage1Response), parameters);
+            IList<ModelBase> items = await client.GetAllAsync(async (ClientRequestParameters p) => new Paginated<ModelBase>(mockClient, "testresource", p, mockPage1Response), new ClientRequestParameters()
+            {
+                Pagination = new ClientRequestPagination()
+                {
+                    Page = 1
+                }
+            });
 
             Assert.AreEqual(5, items.Count);
         }
@@ -93,26 +97,25 @@ namespace UKFast.API.Client.Core.Tests
         [TestMethod]
         public async Task GetAllAsync_EmptyData_ExpectedCalls()
         {
-            ClientRequestParameters parameters = new ClientRequestParameters()
-            {
-                Pagination = new ClientRequestPagination()
-            };
-
             ClientResponse<IList<ModelBase>> mockPage1Response = GetListResponse(new List<ModelBase>(), 3);
-            mockPage1Response.Body.Metadata.Pagination.CurrentPage = 1;
-
             ClientResponse<IList<ModelBase>> mockPage2Response = GetListResponse(new List<ModelBase>(), 3);
-            mockPage2Response.Body.Metadata.Pagination.CurrentPage = 2;
-
             ClientResponse<IList<ModelBase>> mockPage3Response = GetListResponse(new List<ModelBase>(), 3);
-            mockPage3Response.Body.Metadata.Pagination.CurrentPage = 3;
 
             IUKFastClient mockClient = Substitute.For<IUKFastClient>();
-            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 2)).Returns(Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", parameters, mockPage2Response)));
-            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 3)).Returns(Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", parameters, mockPage3Response)));
+            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 2)).Returns(x =>
+            {
+                return Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", x.ArgAt<ClientRequestParameters>(1), mockPage2Response));
+            });
+            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 3)).Returns(x =>
+            {
+                return Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", x.ArgAt<ClientRequestParameters>(1), mockPage3Response));
+            });
 
             IUKFastClient client = new TestUKFastClient(null);
-            IList<ModelBase> items = await client.GetAllAsync(async (ClientRequestParameters p) => new Paginated<ModelBase>(mockClient, "testresource", p, mockPage1Response), parameters);
+            IList<ModelBase> items = await client.GetAllAsync(async (ClientRequestParameters p) => new Paginated<ModelBase>(mockClient, "testresource", p, mockPage1Response), new ClientRequestParameters()
+            {
+                Pagination = new ClientRequestPagination()
+            });
 
             Assert.AreEqual(0, items.Count);
         }
@@ -120,26 +123,22 @@ namespace UKFast.API.Client.Core.Tests
         [TestMethod]
         public async Task GetAllAsync_NullData_ExpectedCalls()
         {
-            ClientRequestParameters parameters = new ClientRequestParameters()
-            {
-                Pagination = new ClientRequestPagination()
-            };
-
             ClientResponse<IList<ModelBase>> mockPage1Response = GetListResponse(null, 3);
-            mockPage1Response.Body.Metadata.Pagination.CurrentPage = 1;
-
             ClientResponse<IList<ModelBase>> mockPage2Response = GetListResponse(null, 3);
-            mockPage2Response.Body.Metadata.Pagination.CurrentPage = 2;
-
             ClientResponse<IList<ModelBase>> mockPage3Response = GetListResponse(null, 3);
-            mockPage3Response.Body.Metadata.Pagination.CurrentPage = 3;
 
             IUKFastClient mockClient = Substitute.For<IUKFastClient>();
-            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 2)).Returns(Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", parameters, mockPage2Response)));
-            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 3)).Returns(Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", parameters, mockPage3Response)));
+            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 2)).Returns(x =>
+            {
+                return Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", x.ArgAt<ClientRequestParameters>(1), mockPage2Response));
+            });
+            mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 3)).Returns(x =>
+            {
+                return Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", x.ArgAt<ClientRequestParameters>(1), mockPage3Response));
+            });
 
             IUKFastClient client = new TestUKFastClient(null);
-            IList<ModelBase> items = await client.GetAllAsync(async (ClientRequestParameters p) => new Paginated<ModelBase>(mockClient, "testresource", p, mockPage1Response), parameters);
+            IList<ModelBase> items = await client.GetAllAsync(async (ClientRequestParameters p) => new Paginated<ModelBase>(mockClient, "testresource", p, mockPage1Response), null);
 
             Assert.AreEqual(0, items.Count);
         }
@@ -148,10 +147,7 @@ namespace UKFast.API.Client.Core.Tests
         public async Task GetAllAsync_NullParameters_ExpectedConfiguredParameters()
         {
             ClientResponse<IList<ModelBase>> mockPage1Response = GetListResponse(null, 2);
-            mockPage1Response.Body.Metadata.Pagination.CurrentPage = 1;
-
             ClientResponse<IList<ModelBase>> mockPage2Response = GetListResponse(null, 2);
-            mockPage2Response.Body.Metadata.Pagination.CurrentPage = 2;
 
             IUKFastClient mockClient = Substitute.For<IUKFastClient>();
             mockClient.GetPaginatedAsync<ModelBase>("testresource", Arg.Is<ClientRequestParameters>(x => x.Pagination.Page == 2 && x.Pagination.PerPage == 99)).Returns(Task.Run(() => new Paginated<ModelBase>(mockClient, "testresource", null, mockPage2Response)));

--- a/UKFast.API.Client.Core/Models/Paginated.cs
+++ b/UKFast.API.Client.Core/Models/Paginated.cs
@@ -28,7 +28,7 @@ namespace UKFast.API.Client.Models
         {
             get
             {
-                return this.Pagination.CurrentPage;
+                return (this.Parameters.Pagination.Page > 0) ? this.Parameters.Pagination.Page : 1;
             }
         }
 
@@ -45,6 +45,7 @@ namespace UKFast.API.Client.Models
             this.Client = client;
             this.Resource = resource;
             this.Parameters = parameters ?? new ClientRequestParameters();
+            this.Parameters.Pagination = this.Parameters.Pagination ?? new ClientRequestPagination();
             this.Items = response?.Body?.Data;
             this.Pagination = response?.Body?.Metadata?.Pagination ?? new ClientResponseMetadataPagination();
         }


### PR DESCRIPTION
The `current_page` property isn't always present in the response pagination metadata. This PR updates the Paginated<T>.CurrentPage property to use the request pagination `Page` property instead