### PR TITLE
Custom serializer

### DIFF
--- a/UKFast.API.Client.Core/ClientConnection.cs
+++ b/UKFast.API.Client.Core/ClientConnection.cs
@@ -8,7 +8,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
-using System.Xml.Linq;
+using UKFast.API.Client.Json;
 using UKFast.API.Client.Models;
 using UKFast.API.Client.Request;
 using UKFast.API.Client.Response;
@@ -112,7 +112,7 @@ namespace UKFast.API.Client
         }
 
         /// <summary>
-        /// Invokes a service request asyncronously
+        /// Invokes a service request asynchronously
         /// </summary>
         /// <param name="request">Instance of ClientRequest object</param>
         public async Task<ClientResponse<T>> InvokeAsync<T>(string resource, ClientRequestMethod method, object body = null)
@@ -126,7 +126,7 @@ namespace UKFast.API.Client
         }
 
         /// <summary>
-        /// Invokes a service request asyncronously
+        /// Invokes a service request asynchronously
         /// </summary>
         /// <param name="request">Instance of ClientRequest object</param>
         public async Task<ClientResponse<T>> InvokeAsync<T>(ClientRequest request)
@@ -146,11 +146,11 @@ namespace UKFast.API.Client
             ClientResponseBody<T> body = null;
             try
             {
-                body = Newtonsoft.Json.JsonConvert.DeserializeObject<ClientResponseBody<T>>(responseBody, new Newtonsoft.Json.JsonSerializerSettings() { NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore });
-            }
-            catch
-            {
-                throw new Exception.UKFastClientRequestException((int)response.StatusCode, responseBody);
+				body = Newtonsoft.Json.JsonConvert.DeserializeObject<ClientResponseBody<T>>(responseBody, new UKFastJsonConverter());
+			}
+            catch (System.Exception ex)
+			{
+				throw new Exception.UKFastClientRequestException((int)response.StatusCode, responseBody, ex);
             }
 
             return new ClientResponse<T>()

--- a/UKFast.API.Client.Core/Exception/UKFastClientException.cs
+++ b/UKFast.API.Client.Core/Exception/UKFastClientException.cs
@@ -8,5 +8,6 @@ namespace UKFast.API.Client.Exception
     {
         public UKFastClientException() { }
         public UKFastClientException(string message) : base(message) { }
-    }
+        public UKFastClientException(string message, System.Exception innerException) : base(message, innerException) { }
+	}
 }

--- a/UKFast.API.Client.Core/Exception/UKFastClientRequestException.cs
+++ b/UKFast.API.Client.Core/Exception/UKFastClientRequestException.cs
@@ -20,9 +20,13 @@ namespace UKFast.API.Client.Exception
         public UKFastClientRequestException(int statusCode, string rawResponse) : base(GetErrorMessage(statusCode, rawResponse))
         {
             this.StatusCode = statusCode;
+		}
+
+        public UKFastClientRequestException(int statusCode, string rawResponse, System.Exception innerException) : base(GetErrorMessage(statusCode, rawResponse), innerException)
+        {
         }
 
-        private static string GetErrorMessage(int statusCode, IEnumerable<ClientResponseError> errors)
+		private static string GetErrorMessage(int statusCode, IEnumerable<ClientResponseError> errors)
         {
             return $"Request failed with status code [{statusCode}]: " + ((errors != null) ? string.Join("; ", errors.Select(x => x.ToString())) : null);
         }

--- a/UKFast.API.Client.Core/Json/UkfastJsonConverter.cs
+++ b/UKFast.API.Client.Core/Json/UkfastJsonConverter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace UKFast.API.Client.Json
+{
+	public class UKFastJsonConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			writer.WriteValue(value.ToString());
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			serializer.NullValueHandling = NullValueHandling.Ignore;
+
+			bool isNullable = IsNullableType(objectType);
+
+			Type enumType = isNullable ? Nullable.GetUnderlyingType(objectType) : objectType;
+
+			string[] names = Enum.GetNames(enumType ?? throw new InvalidOperationException());
+
+			if (reader.TokenType == JsonToken.String)
+			{
+				string enumText = reader.Value.ToString();
+
+				if (!string.IsNullOrEmpty(enumText))
+				{
+					string match = names.FirstOrDefault(n => string.Equals(n, enumText, StringComparison.OrdinalIgnoreCase));
+
+					if (match != null)
+					{
+						return Enum.Parse(enumType, match);
+					}
+				}
+			}
+			else if (reader.TokenType == JsonToken.Integer)
+			{
+				int enumVal = Convert.ToInt32(reader.Value);
+				int[] values = (int[]) Enum.GetValues(enumType);
+				if (values.Contains(enumVal))
+				{
+					return Enum.Parse(enumType, enumVal.ToString());
+				}
+			}
+
+			if (!isNullable)
+			{
+				string fallbackValue = names.FirstOrDefault(n => string.Equals(n, "Unknown", StringComparison.OrdinalIgnoreCase));
+
+				string defaultName = fallbackValue ?? throw new JsonSerializationException("Unable to parse JSON value");
+
+				return Enum.Parse(enumType, defaultName);
+			}
+
+			return null;
+		}
+
+		public override bool CanConvert(Type objectType)
+		{
+
+			Type type = IsNullableType(objectType) ? Nullable.GetUnderlyingType(objectType) : objectType;
+
+			return type.IsEnum;
+		}
+
+		private static bool IsNullableType(Type t)
+		{
+			return (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>));
+		}
+	}
+}


### PR DESCRIPTION
Add custom JSON serializer to allow us to use a fallback enum value if enum does not contain an appropriate match. 

Enums should have an "Unknown" value that will be used to fallback to in the event that the actual string being deserialized doesn't find a match. 

This PR also added override on UKFastClientException to add innerException to the output for better debugging